### PR TITLE
A compilation fix, and minor issue with a NULL reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 TOPDIR := $(shell pwd)
 
-VERSION := 0.1
+PACKAGE := altera-stapl
+VERSION := 0.2
+TARGET_ARCH := $(if $(TARGET_PREFIX),$(patsubst %-,%,$(TARGET_PREFIX)),$(shell uname -m))
 
 # install directories
 PREFIX ?= /usr
@@ -8,13 +10,14 @@ BINDIR ?= $(PREFIX)/bin
 DESTDIR ?=
 
 ifeq ($(shell test -d .git && echo 1),1)
-VERSION := $(shell git describe --abbrev=8 --dirty --always --tags --long)
+VERSION := $(shell git describe --dirty --tags --always)
 endif
 
 EXTRA_CFLAGS = -Wall -Wno-pointer-sign -DVERSION=\"$(VERSION)\"
 
 SOURCES := $(wildcard *.c)
 OBJECTS := $(SOURCES:.c=.o)
+DIST    := Makefile COPYING README.md $(SOURCES) $(wildcard *.h)
 
 programs = jbi
 
@@ -32,3 +35,12 @@ altera-stapl: $(OBJECTS)
 
 install: altera-stapl
 	install -D -m 0755 altera-stapl $(DESTDIR)$(BINDIR)/altera-stapl
+
+dist:
+	tar --transform 's,^,$(PACKAGE)-$(VERSION)/,' -czf $(PACKAGE)-$(VERSION).tar.gz $(DIST)
+
+install-tgz:
+	rm -rf /tmp/$(PACKAGE)-$(VERSION)
+	make install DESTDIR=/tmp/$(PACKAGE)-$(VERSION) PREFIX=/usr/local
+	tar -czf $(PACKAGE)-$(VERSION).bin.$(TARGET_ARCH).tgz -C /tmp/$(PACKAGE)-$(VERSION) . --owner=0 --group=0
+	rm -rf /tmp/$(PACKAGE)-$(VERSION)

--- a/altera-gpio.c
+++ b/altera-gpio.c
@@ -423,7 +423,7 @@ int main(int argc, char **argv)
 
 			for (i = 0; i < action_count; i++) {
 				char *action_name;
-				char *description;
+				char *description = NULL;
 				struct altera_procinfo *procedure_list;
 				struct altera_procinfo *procptr;
 

--- a/altera-jtag.c
+++ b/altera-jtag.c
@@ -24,6 +24,7 @@
  */
 
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <stdlib.h>
 #include <unistd.h>
 #include "altera.h"

--- a/altera.c
+++ b/altera.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <inttypes.h>
 #include "altera.h"
 #include "altera-jtag.h"
 
@@ -444,7 +445,7 @@ int altera_execute(uint8_t *p, int32_t program_size, char *action,
 						? get_unaligned_be16(&p[offset + 1])
 						: get_unaligned_be32(&p[offset + 1]);
 			name = &p[str_table + name_id];
-			fprintf(stderr, "Variable #%d (%s) attrs=%x value=%08lx var_size=%d orig_value=%08x\n",
+			fprintf(stderr, "Variable #%d (%s) attrs=%x value=%" PRIxPTR " var_size=%d orig_value=%08x\n",
 					i, name, attrs[i], vars[i], var_size[i], value);
 		}
 	}


### PR DESCRIPTION
Thanks for providing this code, it worked very well for us.

We are compiling on an iMX6 using gcc (from a freescale community YOCTO build) and found a couple of compile warnings - easily fixable.

More importantly the jbc file we where using - it did not have any descriptions in it, and as the description pointer was not reset to NULL, this resulted in a junk being displayed on the screen.